### PR TITLE
[Policy] Strengthening Code Review Response Guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,10 +34,10 @@ nlab-agent uses the `.nlab/` directory for persistent state:
 The following is a high-level map of available skill categories. **Always check the `skills/` directory for the full list and latest documentation.**
 
 ### 📝 PM & Planning
-- `writing-plans`, `brainstorming`, `autoresearch`, `deep-interview`
+- `writing-plans`, `brainstorming`, `autoresearch`, `deep-interview`, `create-gh-issue`
 
 ### 🛠 Engineering & Debugging
-- `systematic-debugging`, `autopilot`, `test-driven-development`, `finishing-a-development-branch`, `create-gh-issue`
+- `systematic-debugging`, `autopilot`, `test-driven-development`, `finishing-a-development-branch`
 
 ### 🛡 Quality & Workflow
 - `requesting-code-review`, `receiving-code-review`, `verification-before-completion`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,6 @@ This repository defines the core capabilities, operating protocols, and state-ma
 <working_agreements>
 - All implementation work must follow the TDD cycle when applicable.
 - Code reviews must be rigorous and evidence-driven.
-- **Code Review Response Policy**: When responding to review comments, strictly follow the `Commit -> Push -> Comment` sequence. Every response must mention the reviewer, provide technical rationale, and include a link to the change.
 - Use `deep-interview` to resolve ambiguity before starting high-effort tasks.
 - **Source of Truth**: The `skills/` directory is the primary source of truth. Always browse it to discover the latest tools.
 </working_agreements>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This repository defines the core capabilities, operating protocols, and state-ma
 <working_agreements>
 - All implementation work must follow the TDD cycle when applicable.
 - Code reviews must be rigorous and evidence-driven.
+- **Code Review Response Policy**: When responding to review comments, strictly follow the `Commit -> Push -> Comment` sequence. Every response must mention the reviewer, provide technical rationale, and include a link to the change.
 - Use `deep-interview` to resolve ambiguity before starting high-effort tasks.
 - **Source of Truth**: The `skills/` directory is the primary source of truth. Always browse it to discover the latest tools.
 </working_agreements>

--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -10,11 +10,15 @@ description: Use when receiving code review feedback. Ensures technical rigor an
 
 ## The Response Pattern
 1. **READ**: Complete feedback without reacting.
-2. **UNDERSTAND**: Restate requirement in own words or ask for clarification.
+2. **UNDERSTAND**: Address comments individually. Restate requirement or ask for clarification.
 3. **VERIFY**: Check against codebase reality.
 4. **EVALUATE**: Is this technically sound for THIS specific codebase?
-5. **RESPOND**: Technical acknowledgment or reasoned pushback.
-6. **IMPLEMENT**: One item at a time, test each.
+5. **IMPLEMENT**: **Commit** the fix for the specific comment.
+6. **SYNC**: **Push** to remote.
+7. **RESPOND**: **Comment** on the review with:
+    - @mention of the reviewer.
+    - Technical rationale for the change (or non-change).
+    - Link to the commit/diff.
 
 ## Handling Feedback
 - **NEVER** use performative agreement like "You're absolutely right!" or "Great point!".
@@ -31,3 +35,7 @@ description: Use when receiving code review feedback. Ensures technical rigor an
 3. Simple fixes (typos, imports).
 4. Complex fixes (refactoring, logic).
 5. Test each fix individually.
+
+## Unresolved Comments
+- Always handle unresolved comments before closing the review cycle.
+- If a comment cannot be addressed immediately, provide a clear timeline or reason for postponement.


### PR DESCRIPTION
Closes #1. This PR formalizes the code review response guidelines. It updates AGENTS.md and the receiving-code-review skill with mandatory workflow rules (Commit -> Push -> Comment) and response requirements (mention reviewer, technical rationale, and change links).